### PR TITLE
include missing <cstdint>

### DIFF
--- a/src/mcp9808/mcp9808.hpp
+++ b/src/mcp9808/mcp9808.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <interfaces/iTemperature.hpp>

--- a/src/micsv89/micsv89.hpp
+++ b/src/micsv89/micsv89.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 


### PR DESCRIPTION
gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included [1]. Explicitly include it for uint{32,64}_t.

[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Signed-off-by: Khem Raj <raj.khem@gmail.com>